### PR TITLE
Bumped country picker version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   shared_preferences: ^2.0.7
   provider: ^6.0.5
   csv: ^5.0.0
-  country_code_picker: ^2.0.2
+  country_code_picker: ^3.0.0
   intl: ^0.17.0
 
 dev_dependencies:


### PR DESCRIPTION
Version bump to fix a dependency breakage that was present in previous code.

The `dashboard_charts` PR (https://github.com/go-go-go-ltd/esimgo-cloud/pull/236) branch has been updated to use this branch.