### PR TITLE
created new api parameter sortIn for a separated list of sort columns

### DIFF
--- a/lib/datasource.dart
+++ b/lib/datasource.dart
@@ -265,6 +265,7 @@ class DataSourceApi extends DataSource {
     this.searchPath = "",
     this.searchQueryParameter = "",
     this.disableFiltersOnSearch = true,
+    this.separatedSortColumns = const [],
   }) : super(0, 15, defaultSortOrder, {}, isZeroIndexed);
 
   /// Domain Name of the API to call including http/https.
@@ -303,6 +304,9 @@ class DataSourceApi extends DataSource {
   /// Disable Filters when searching.
   final bool disableFiltersOnSearch;
 
+  /// List of Columns that will be sent to the API endpoint using the parameter `sortIn`.
+  final List<String> separatedSortColumns;
+
   /// Retrieve data from the API, and package into a DataSourceResponse
   ///
   /// NOTE: This loader has a rather significant side effect: When DataGridExportType == asyncEmail,
@@ -340,12 +344,22 @@ class DataSourceApi extends DataSource {
         urlQuery = {
           'page': ["${_isZeroIndexed ? 0 : 1}"],
           'limit': ["$_currentTotal"],
-          'sort': _sort.entries.map((e) => "${e.key}:${e.value}").toList(),
+          'sort':
+              _sort.entries.map((e) => !separatedSortColumns.contains(e.key) ? "${e.key}:${e.value}" : null).where((value) => value != null).toList(),
+          'sortIn': _sort.entries
+              .map((e) => separatedSortColumns.contains(e.key) ? "${e.key}:name:${e.value}" : null)
+              .where((value) => value != null)
+              .toList()
         };
         break;
       case DataGridExportType.asyncEmail:
         urlQuery = {
-          'sort': _sort.entries.map((e) => "${e.key}:${e.value}").toList(),
+          'sort':
+              _sort.entries.map((e) => !separatedSortColumns.contains(e.key) ? "${e.key}:${e.value}" : null).where((value) => value != null).toList(),
+          'sortIn': _sort.entries
+              .map((e) => separatedSortColumns.contains(e.key) ? "${e.key}:name:${e.value}" : null)
+              .where((value) => value != null)
+              .toList()
         };
 
         // An extra parameter supplied to our API endpoint informs it that it
@@ -358,7 +372,12 @@ class DataSourceApi extends DataSource {
         urlQuery = {
           'page': ["$_page"],
           'limit': ["$_pageLimit"],
-          'sort': _sort.entries.map((e) => "${e.key}:${e.value}").toList(),
+          'sort':
+              _sort.entries.map((e) => !separatedSortColumns.contains(e.key) ? "${e.key}:${e.value}" : null).where((value) => value != null).toList(),
+          'sortIn': _sort.entries
+              .map((e) => separatedSortColumns.contains(e.key) ? "${e.key}:name:${e.value}" : null)
+              .where((value) => value != null)
+              .toList()
         };
         break;
     }


### PR DESCRIPTION
**STORY:** https://www.pivotaltracker.com/story/show/186426115

**CHANGES:** added functionality to allow a second, separate list of columns to sort, to be passed to the API endpoint using the `sortIn` parameter.

**CONTEXT (esimgo):** Doing this will allow the `country` field to be passed separately to the `organisation-operations` endpoint and therefore can have a custom sort by country name.