### PR TITLE
added new exportLimit parameter

### DIFF
--- a/lib/advanced_data_grid.dart
+++ b/lib/advanced_data_grid.dart
@@ -120,6 +120,7 @@ class DataGrid extends StatefulWidget {
     this.onSelectionChange,
     this.onRowTap,
     this.exportTypes = const [],
+    this.exportLimit,
     this.primaryColor,
     this.overrideElevatedButtonStyle,
     this.overrideTextButtonStyle,
@@ -186,6 +187,9 @@ class DataGrid extends StatefulWidget {
 
   /// If provided, will enable Export functionality from the Grid via the specified types.
   final List<DataGridExportType> exportTypes;
+
+  /// If provided, the "All Pages" text will change to "All Pages (limited to {exportLimit} rows)"
+  final String? exportLimit;
 
   /// Override the Primary Colour of the Grid. By default will use Theme Primary Colour.
   final Color? primaryColor;
@@ -771,6 +775,7 @@ class _DataGridState extends State<DataGrid> {
                                                           .toList(),
                                                       source: widget.source,
                                                       exportTypes: widget.exportTypes,
+                                                      exportLimit: widget.exportLimit,
                                                       overrideButtonStyle: widget.overrideElevatedButtonStyle,
                                                       primaryColor:
                                                           widget.primaryColor ?? Theme.of(context).colorScheme.primary,

--- a/lib/export_data.dart
+++ b/lib/export_data.dart
@@ -14,12 +14,14 @@ class ExportDataGridModal extends StatefulWidget {
     required this.columns,
     required this.source,
     required this.exportTypes,
+    this.exportLimit,
     this.overrideButtonStyle,
     required this.primaryColor,
   });
 
   final String title;
   final List<DataGridColumn> columns;
+  final String? exportLimit;
 
   /// The source for data received
   final DataSource source;
@@ -323,7 +325,9 @@ class _ExportDataGridModalState extends State<ExportDataGridModal> {
                           // All pages data export
                           widget.exportTypes.contains(DataGridExportType.allPages)
                               ? RadioListTile<DataGridExportType>(
-                                  title: const Text('All Pages'),
+                                  title: Text(
+                                    'All Pages ${widget.exportLimit != null ? '(limited to ${widget.exportLimit} rows)' : ''}',
+                                  ),
                                   activeColor: widget.primaryColor,
                                   tileColor: _exportType == DataGridExportType.allPages ? widget.primaryColor.withOpacity(0.1) : Colors.white,
                                   shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(5)),


### PR DESCRIPTION
Added a new param so we can UI users that there is a limit to how many rows they can export. Made it dynamic so by default it will just say "All Pages" but if we provide a limit it changes to "All Pages (limited to `exportLimit` rows)".

Pivotal:
https://www.pivotaltracker.com/story/show/187354332

![Screenshot 2024-04-17 at 09 46 07](https://github.com/Koroutine/advanced-data-grid/assets/103049357/9b6cda73-7b9e-4e81-b0eb-5fb2b320b460)